### PR TITLE
Update Screek-Light-Sensor-LS2.yaml

### DIFF
--- a/LS2/Screek-Light-Sensor-LS2.yaml
+++ b/LS2/Screek-Light-Sensor-LS2.yaml
@@ -21,7 +21,7 @@ api:
 
 ota:
   - platform: esphome
-    password: !secret ls2_ota_password
+    password: "your-ota-password"
 
 web_server:
   port: 80


### PR DESCRIPTION
Change OTA password to not read from secret so that it can be overridden in ESPHome.

Tested working and reporting correct brightness in ESPHome 2026.5.3.